### PR TITLE
Create custom answers file for connected install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Josh Springer: <springer@redhat.com>, [GitHub](https://github.com/josh-springer)
 
 Contributors
 ------------------
-Glenn Snead <email@here.com>, [GitHub](https://github.com/<your-account>)
+Glenn Snead <glennsnead@gmail.com>, [GitHub](https://github.com/killroy1971)

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -25,7 +25,7 @@
   tags:
     - hostname
 
-- name: firewall | Enable ports in firewall 
+- name: firewall | Enable ports in firewall
   firewalld:
     port: "{{ item }}"
     permanent: yes
@@ -33,7 +33,7 @@
   with_items:
     - "{{ firewall_ports }}"
 
-- name: firewall | Enable service in firewall 
+- name: firewall | Enable service in firewall
   firewalld:
     service: "{{ item }}"
     permanent: yes

--- a/tasks/install_satellite.yml
+++ b/tasks/install_satellite.yml
@@ -3,20 +3,38 @@
 
 ## TODO: Need to work on a new answer file
 #- name: install_satellite | Copy satellite answer file
-#  template: 
-#    src: satellite-answers.yaml 
+#  template:
+#    src: satellite-answers.yaml
 #    dest: /etc/foreman-installer/scenarios.d/satellite-answers.yaml
 #  tags:
 #  - install_satellite
 
-- name: install_satellite | Verify Foreman exists 
-  stat: 
+- name: Load Satellite answer file varriables
+  include_vars: file=../vars/answer-file.yml
+
+- name: install_satellite | Verify Foreman exists
+  stat:
     path: /etc/init.d/foreman
   register: foreman_location
   tags:
     - install_satellite
 
-- name: install_satellite | Install Satellite with desired scenario 
+- name: Copy satellite answers file to target
+  copy:
+    src: ../templates/satellite-answers.yaml
+    dest: /etc/foreman-installer/scenarios.d/satellite-answers.yaml
+  when: foreman_location.stat.exists
+  tags:
+    - install_satellite
+
+- name: Update target Satellite answers file
+  replace: dest=/etc/foreman-installer/scenarios.d/satellite-answers.yaml regexp={{ item.regex }} replace={{ item.setting }}
+  with_items: "{{ answer_file_settings }}"
+  when: foreman_location.stat.exists
+  tags:
+    - install_satellite
+
+- name: install_satellite | Install Satellite with desired scenario
   command: /usr/sbin/satellite-installer --scenario "{{ satellite_scenario }}"
   when: foreman_location.stat.exists
   tags:

--- a/tasks/install_software.yml
+++ b/tasks/install_software.yml
@@ -2,13 +2,13 @@
 - name: install_software | Clear out existing repos
   command: subscription-manager repos --disable "*"
 
-- name: install_software | Enable the correct repos for Satellite 
-  command: subscription-manager repos  --enable rhel-7-server-satellite-{{satellite_version}}-rpms --enable rhel-7-server-rpms --enable rhel-server-rhscl-7-rpms 
+- name: install_software | Enable the correct repos for Satellite
+  command: subscription-manager repos  --enable rhel-7-server-satellite-{{satellite_version}}-rpms --enable rhel-7-server-rpms --enable rhel-server-rhscl-7-rpms
 
 - name: install_software | Clean out any residual metadata from old repositories
   command: yum clean all
 
-- name: install_software | Update currently installed  packages 
+- name: install_software | Update currently installed  packages
   yum:
     name: "*"
     state: latest
@@ -18,4 +18,4 @@
     name: "{{ item }}"
     state: latest
   with_items:
-    - "{{ packages_list }}" 
+    - "{{ packages_list }}"

--- a/tasks/registration.yml
+++ b/tasks/registration.yml
@@ -1,5 +1,5 @@
 ---
-- name: registration | Register machine with RHN 
+- name: registration | Register machine with RHN
   command: /usr/bin/subscription-manager register --username={{ rhn_user }} --password={{ rhn_password }} --name={{ hostname_full }}
   tags:
     - rhn

--- a/templates/README.md
+++ b/templates/README.md
@@ -3,6 +3,6 @@ This satellite-answers.yml file was taken from a "connected" satellite installat
 does not run DNS, DHCP, or TFTP.  It does not use a proxy server.  It is not connected
 to external authentication, and it uses self-generated SSL certificates.
 
-Update the ../var/main.yml file to fit your environment.
+Update the ../var/answer-file.yml file to fit your environment.
 If you successfully enable one of the disabled services using these playbooks,
 please submit a pull request.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,8 @@
+Note: This is a WiP (Work in Progress).
+This satellite-answers.yml file was taken from a "connected" satellite installation that
+does not run DNS, DHCP, or TFTP.  It does not use a proxy server.  It is not connected
+to external authentication, and it uses self-generated SSL certificates.
+
+Update the ../var/main.yml file to fit your environment.
+If you successfully enable one of the disabled services using these playbooks,
+please submit a pull request.

--- a/templates/satellite-answers.yaml
+++ b/templates/satellite-answers.yaml
@@ -1,60 +1,334 @@
+# Format:
+# <classname>: false - don't include this class
+# <classname>: true - include and use the defaults
+# <classname>:
+#   <param>: <value> - include and override the default(s)
+#
+# See params.pp in each class for what options are available
+
 ---
+  capsule:
+    parent_fqdn: "{{ parent_fqdn }}"
+    certs_tar:
+    pulp_master: true
+    pulp_admin_password: "{{ pulp_admin_passwd }}"
+    pulp_oauth_effective_user: admin
+    pulp_oauth_key: katello
+    pulp_oauth_secret:
+    puppet: true
+    puppet_ca_proxy:
+    reverse_proxy: false
+    reverse_proxy_port: "8443"
+    rhsm_url: /rhsm
+    qpid_router: true
+    qpid_router_hub_addr: "0.0.0.0"
+    qpid_router_hub_port: "5646"
+    qpid_router_agent_addr: "0.0.0.0"
+    qpid_router_agent_port: "5647"
+    qpid_router_broker_addr: "{{ system_name }}"
+    qpid_router_broker_port: "5671"
+    enable_ostree: false
   certs:
+    log_dir: /var/log/certs
+    node_fqdn: "{{ system_name }}"
     generate: true
+    regenerate: false
+    regenerate_ca: false
     deploy: true
+    ca_common_name: "{{ system_name }}"
+    country: US
+    state: "North Carolina"
+    city: Raleigh
+    org: Katello
+    org_unit: SomeOrgUnit
+    expiration: "7300"
+    ca_expiration: "36500"
+    server_cert:
+    server_key:
+    server_cert_req:
+    server_ca_cert:
+    pki_dir: /etc/pki/katello
+    ssl_build_dir: /root/ssl-build
+    password_file_dir: "certs::params::password_file_dir"
+    user: root
     group: foreman
-  katello:
-    package_names:
-      - katello
-      - tfm-rubygem-katello
+    default_ca_name: katello-default-ca
+    server_ca_name: katello-server-ca
   foreman:
-    organizations_enabled: true
-    locations_enabled: true
-    initial_organization: "{{ organization }}"
-    initial_location: "{{ location }}"
+    foreman_url: "{{ system_name_https }}"
+    puppetrun: false
+    unattended: true
+    authentication: true
+    passenger: true
+    passenger_ruby: /usr/bin/tfm-ruby
+    passenger_ruby_package: tfm-rubygem-passenger-native
+    plugin_prefix: tfm-rubygem-foreman_
+    use_vhost: true
+    servername: "{{ system_name }}"
+    serveraliases:
+      - foreman
+    ssl: true
     custom_repo: true
+    repo: stable
     configure_epel_repo: false
     configure_scl_repo: false
-    ssl: true
-    server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-    server_ssl_key: /etc/pki/katello/private/katello-apache.key
+    configure_brightbox_repo: false
+    selinux:
+    gpgcheck: true
+    version: present
+    db_manage: true
+    db_type: postgresql
+    db_adapter:
+    db_host:
+    db_port:
+    db_database:
+    db_username: "{{ satellite_db_username }}"
+    db_password: "{{ satellite_db_password }}"
+    db_sslmode:
+    db_pool: 5
+    apipie_task: "apipie:cache:index"
+    app_root: /usr/share/foreman
+    manage_user: true
+    user: foreman
+    group: foreman
+    user_groups:
+      - puppet
+    environment: production
+    puppet_home: /var/lib/puppet
+    locations_enabled: true
+    organizations_enabled: true
+    passenger_interface:
     server_ssl_ca: /etc/pki/katello/certs/katello-default-ca.crt
     server_ssl_chain: /etc/pki/katello/certs/katello-default-ca.crt
+    server_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
+    server_ssl_certs_dir: ""
+    server_ssl_key: /etc/pki/katello/private/katello-apache.key
+    server_ssl_crl: false
+    oauth_active: true
+    oauth_map_users: false
+    oauth_consumer_key: C9vvEUHgxrpbLqMBQBfM6sYxwSKHFzdt
+    oauth_consumer_secret: osTcHa25wqrBDc449NsraqNpmY2zBKQn
+    passenger_prestart: true
+    passenger_min_instances: "1"
+    passenger_start_timeout: "600"
+    admin_username: "{{ satellite_admin_user }}"
+    admin_password: "{{ satellite_admin_passwd }}"
+    admin_first_name:
+    admin_last_name:
+    admin_email:
+    initial_organization: "{{ satellite_initial_organization }}"
+    initial_location: "{{ satellite_initial_location }}"
+    ipa_authentication: false
+    http_keytab: /etc/httpd/conf/http.keytab
+    pam_service: foreman
+    ipa_manage_sssd: true
     websockets_encrypt: true
     websockets_ssl_key: /etc/pki/katello/private/katello-apache.key
     websockets_ssl_cert: /etc/pki/katello/certs/katello-apache.crt
-    unattended: true
-    admin_username: "{{ admin_user }}"
-    admin_password: "{{ admin_passwd }}"
-  # capsule:
-  #   register_in_foreman: true
-  #   pulp_master: true
-  #   puppet: true
-  #   puppetca: true
-  #   templates: false
-  #   tftp: true
-  #   tftp_servername: "{{ ip_address_sat }}"
-  #   bmc: false
-  #   bmc_default_provider: ipmitool
-    # dhcp: true
-    # dhcp_option_domain:
-    #   - "{{ dns_zone }}"
-    # dhcp_interface: "{{ dhcp_mgmt_interface }}"
-    # dhcp_gateway: "{{ gateway }}"
-    # dhcp_range: "{{ dhcp_start }} {{ dhcp_end }}"
-    # dhcp_nameservers: "{{ ip_address_sat }}"
-    # dns: true
-    # dns_zone: "{{ dns_zone }}"
-    # dns_reverse: "{{ dns_reverse_zone }}"
-    # dns_inteface: "{{ dns_interface }}"
-    # dns_forwarders:
-    #   - "{{ forwarder_dns }}"
-  "foreman::plugin::bootdisk": true
-  "foreman::plugin::discovery": true
+    logging_level: info
+    loggers: {}
+    email_conf: email.yaml
+    email_source: email.yaml.erb
+    email_delivery_method:
+    email_smtp_address:
+    email_smtp_port: 25
+    email_smtp_domain:
+    email_smtp_authentication: none
+    email_smtp_user_name:
+    email_smtp_password:
+  "foreman::plugin::bootdisk": false
+  "foreman::plugin::discovery":
+    install_images: false
+    tftp_root: /var/lib/tftpboot
+    source_url: "http://downloads.theforeman.org/discovery/releases/latest/"
+    image_name: fdi-image-latest.tar
+  "foreman::plugin::openscap":
+    configure_openscap_repo: false
+  "foreman::plugin::remote_execution": {}
+  "foreman::plugin::tasks":
+    package: tfm-rubygem-foreman-tasks
+    service: foreman-tasks
   "foreman::plugin::hooks": true
-  "foreman::plugin::tasks": true
-  "foreman::plugin::chef": false
-  "foreman::plugin::default_hostgroup": false
-  "foreman::plugin::puppetdb": false
-  "foreman::plugin::setup": false
-  "foreman::plugin::templates": false
+  foreman_proxy:
+    repo: stable
+    gpgcheck: true
+    custom_repo: true
+    version: present
+    plugin_version: installed
+    bind_host: "*"
+    port:
+    http_port: 8000
+    ssl_port: 9090
+    dir: /usr/share/foreman-proxy
+    user: foreman-proxy
+    log: /var/log/foreman-proxy/proxy.log
+    log_level: ERROR
+    log_buffer: 2000
+    log_buffer_errors: 1000
+    http: true
+    ssl: true
+    ssl_ca: /etc/foreman-proxy/ssl_ca.pem
+    ssl_cert: /etc/foreman-proxy/ssl_cert.pem
+    ssl_key: /etc/foreman-proxy/ssl_key.pem
+    foreman_ssl_ca: /etc/foreman-proxy/foreman_ssl_ca.pem
+    foreman_ssl_cert: /etc/foreman-proxy/foreman_ssl_cert.pem
+    foreman_ssl_key: /etc/foreman-proxy/foreman_ssl_key.pem
+    trusted_hosts:
+      - "{{ system_name }}"
+    ssl_disabled_ciphers: []
+    manage_sudoersd: true
+    use_sudoersd: true
+    puppetca: true
+    puppetca_listen_on: https
+    ssldir: /var/lib/puppet/ssl
+    puppetdir: /etc/puppet
+    autosign_location: /etc/puppet/autosign.conf
+    puppetca_cmd: "/usr/bin/puppet cert"
+    puppet_group: puppet
+    puppetrun: true
+    puppetrun_listen_on: https
+    puppetrun_cmd: "/usr/bin/puppet kick"
+    puppetrun_provider:
+    customrun_cmd: /bin/false
+    customrun_args: "-ay -f -s"
+    puppetssh_sudo: false
+    puppetssh_command: "/usr/bin/puppet agent --onetime --no-usecacheonfailure"
+    puppetssh_user: root
+    puppetssh_keyfile: /etc/foreman-proxy/id_rsa
+    puppetssh_wait: false
+    salt_puppetrun_cmd: puppet.run
+    puppet_user: root
+    puppet_url: "{{ system_name_puppet }}"
+    puppet_ssl_ca: /var/lib/puppet/ssl/certs/ca.pem
+    puppet_ssl_cert: /var/lib/puppet/ssl/certs/"{{ system_name }}".pem
+    puppet_ssl_key: /var/lib/puppet/ssl/private_keys/"{{ system_name }}".pem
+    puppet_use_environment_api:
+    templates: false
+    templates_listen_on: both
+    template_url: "{{ system_name_http }}"
+    logs: false
+    logs_listen_on: https
+    tftp: false
+    tftp_listen_on: https
+    tftp_manage_wget: true
+    tftp_syslinux_root:
+    tftp_syslinux_files:
+    tftp_syslinux_filenames:
+      - /usr/share/syslinux/chain.c32
+      - /usr/share/syslinux/menu.c32
+      - /usr/share/syslinux/memdisk
+      - /usr/share/syslinux/pxelinux.0
+    tftp_root: /var/lib/tftpboot
+    tftp_dirs:
+      - /var/lib/tftpboot/pxelinux.cfg
+      - /var/lib/tftpboot/boot
+      - /var/lib/tftpboot/ztp.cfg
+      - /var/lib/tftpboot/poap.cfg
+    tftp_servername:
+    dhcp: false
+    dhcp_split_config_files: true
+    dhcp_listen_on: https
+    dhcp_managed: true
+    dhcp_provider: isc
+    dhcp_vendor:
+    dhcp_option_domain:
+      - us-gov-west-1.compute.internal
+    dhcp_interface: eth0
+    dhcp_gateway: "192.168.100.1"
+    dhcp_range: false
+    dhcp_nameservers: default
+    dhcp_server: "127.0.0.1"
+    dhcp_config: /etc/dhcp/dhcpd.conf
+    dhcp_leases: /var/lib/dhcpd/dhcpd.leases
+    dhcp_key_name:
+    dhcp_key_secret:
+    dhcp_omapi_port: 7911
+    dns: false
+    dns_split_config_files: true
+    dns_listen_on: https
+    dns_managed: true
+    dns_provider: nsupdate
+    dns_interface: eth0
+    dns_zone: us-gov-west-1.compute.internal
+    dns_reverse: "100.168.192.in-addr.arpa"
+    dns_server: "127.0.0.1"
+    dns_ttl: "86400"
+    dns_tsig_keytab: /etc/foreman-proxy/dns.keytab
+    dns_tsig_principal: "{{ dns_tsig_principal_entry }}"
+    dns_forwarders: []
+    virsh_network: default
+    bmc: false
+    bmc_listen_on: https
+    bmc_default_provider: ipmitool
+    realm: false
+    realm_listen_on: https
+    realm_provider: freeipa
+    realm_keytab: /etc/foreman-proxy/freeipa.keytab
+    realm_principal: "realm-proxy@EXAMPLE.COM"
+    freeipa_remove_dns: true
+    keyfile: /etc/rndc.key
+    register_in_foreman: true
+    foreman_base_url: "{{ system_name_https }}"
+    registered_name: "{{ system_name }}"
+    registered_proxy_url:
+    oauth_effective_user: admin
+    oauth_consumer_key: C9vvEUHgxrpbLqMBQBfM6sYxwSKHFzdt
+    oauth_consumer_secret: osTcHa25wqrBDc449NsraqNpmY2zBKQn
+    puppet_use_cache:
+    puppet_cache_location: /var/cache/foreman-proxy
+  "foreman_proxy::plugin::discovery":
+    install_images: false
+    tftp_root: /var/lib/tftpboot
+    source_url: "http://downloads.theforeman.org/discovery/releases/latest/"
+    image_name: fdi-image-latest.tar
+  "foreman_proxy::plugin::openscap":
+    enabled: true
+    version:
+    listen_on: https
+    openscap_send_log_file: /var/log/foreman-proxy/openscap-send.log
+    spooldir: /var/spool/foreman-proxy/openscap
+    contentdir: /var/lib/foreman-proxy/openscap/content
+    reportsdir: /var/lib/foreman-proxy/openscap/reports
+    failed_dir: /var/lib/foreman-proxy/openscap/failed
+  "foreman_proxy::plugin::pulp":
+    enabled: true
+    listen_on: https
+    pulpnode_enabled: false
+    version:
+    group:
+    pulp_url: "{{ system_name_https }}/pulp"
+    pulp_dir: /var/lib/pulp
+    pulp_content_dir: /var/lib/pulp/content
+    mongodb_dir: /var/lib/mongodb
+  "foreman_proxy::plugin::remote_execution::ssh":
+    enabled: true
+    listen_on: https
+    generate_keys: true
+    ssh_identity_dir: /usr/share/foreman-proxy/.ssh
+    ssh_identity_file: id_rsa_foreman_proxy
+    ssh_keygen: /usr/bin/ssh-keygen
+    local_working_dir: /var/tmp
+    remote_working_dir: /var/tmp
+  katello:
+    user: foreman
+    group: foreman
+    user_groups: foreman
+    oauth_key: katello
+    oauth_secret: YnTmjEv5u8UbssfmvGtLRixkJfz8qBNZ
+    post_sync_token: zEaLJjFfH65kc2ULtpDNKA9C97cSJCch
+    num_pulp_workers: "8"
+    max_tasks_per_pulp_worker: 2
+    log_dir: /var/log/foreman/plugins
+    config_dir: /etc/foreman/plugins
+    use_passenger: "katello::params::use_passenger"
+    proxy_url:
+    proxy_port:
+    proxy_username:
+    proxy_password:
+    cdn_ssl_version:
+    package_names:
+      - katello
+      - tfm-rubygem-katello
+    enable_ostree: false
+    max_keep_alive: 10000
+    repo_export_dir: /var/lib/pulp/katello-export

--- a/templates/satellite-answers.yaml
+++ b/templates/satellite-answers.yaml
@@ -31,18 +31,18 @@
   certs:
     log_dir: /var/log/certs
     node_fqdn: "{{ system_name }}"
-    generate: true
+    generate: "{{ ca_gen_certificate }}"
     regenerate: false
     regenerate_ca: false
     deploy: true
     ca_common_name: "{{ system_name }}"
-    country: US
-    state: "North Carolina"
-    city: Raleigh
-    org: Katello
-    org_unit: SomeOrgUnit
+    country: "{{ ca_country }}"
+    state: "{{ ca_state }}"
+    city: "{{ ca_city }}"
+    org: "{{ ca_org }}"
+    org_unit: "{{ ca_org_unit }}"
     expiration: "7300"
-    ca_expiration: "36500"
+    ca_expiration: "{{ ca_crt_organization }}"
     server_cert:
     server_key:
     server_cert_req:
@@ -52,8 +52,8 @@
     password_file_dir: "certs::params::password_file_dir"
     user: root
     group: foreman
-    default_ca_name: katello-default-ca
-    server_ca_name: katello-server-ca
+    default_ca_name: "{{ ca_default_name }}"
+    server_ca_name: "{{ ca_default_server_name }}"
   foreman:
     foreman_url: "{{ system_name_https }}"
     puppetrun: false

--- a/vars/README.md
+++ b/vars/README.md
@@ -1,0 +1,55 @@
+NOTE: This is currently a development version; not all functions will be in a working order
+
+Varriable Explanation
+=====================
+Firewall Ports
+---------------
+You can open ports using the built-in firewalld services in the first section,
+or you can open ports individually using the second section.
+Just don't use both at the same time.
+By default, SSH and the basic Satellite server ports are opened using the firewall 
+services selections, and the one "Capsule" firewall ports 7911, 8000, and 8443 
+that aren't part of the RH-Satelite-6 service are opened individually.
+
+Ports 16514, 5000, and 5900-5930 should only be opened if there are clients that are
+attempting to communicate with Satellite or a Capusle via these services.
+
+firewall_services:
+  - ssh -- 22/tcp
+  - RH-Satellite-6 -- 80/tcp 443/tcp 5646-5647/tcp 5671/tcp 8140/tcp 8080/tcp 9090/tcp
+  - dns -- 53/udp 53/tcp
+  - dhcp -- 67/udp
+  - dhcpv6 -- 547/udp
+  - tftp -- 69/udp
+  - libvirt-tls - 16514/tcp (libvirt compute resources)
+  - ldap - 389/tcp
+  - ldaps - 636/tcp
+  - docker-registry - 5000/tcp (also for OpenStack)
+  - vnc-server - 5900-5930/tcp (VNC in web UI to hypervisors)
+
+# List of ports to add into the firewall via Firewalld
+firewall_ports:
+  - 22/tcp (SSH)
+  - 53/udp (DNS)
+  - 53/tcp (DNS)
+  - 67/udp (DHCP)
+  - 68/udp
+  - 69/udp (TFTP)
+  - 80/tcp (HTTP)
+  - 389/tcp (LDAP)
+  - 443/tcp (HTTPS)
+  - 639/tcp (LDAPS)
+  - 5000/tcp (Docker and OpenStack)
+  - 5646/tcp (Satellite)
+  - 5647/tcp (Satellite)
+  - 5671/tcp (Satellite)
+  - 5674/tcp (Satellite)
+  - 7911/tcp (Capsule)
+  - 8000/tcp (Capsule)
+  - 8140/tcp (Satellite)
+  - 8443/tcp (Capsule)
+  - 9090/tcp (Satellite)
+  - 16514/tcp (libvirt compute resources)
+
+
+

--- a/vars/README.md
+++ b/vars/README.md
@@ -2,11 +2,19 @@ NOTE: This is currently a development version; not all functions will be in a wo
 
 Varriable Explanation
 =====================
+Satellite Answer File
+---------------------
+This assumes that you have installed Satellite 6 before and that you know which varriables
+to change.  The default answers will create a connected server "satellite.example.com." 
+
+TODO: Add varriables to configure DNS/DHCP/TFTP services.
+      Add varriables to set up oAuth or AD integration.
+
 Firewall Ports
 ---------------
 You can open ports using the built-in firewalld services in the first section,
 or you can open ports individually using the second section.
-Just don't use both at the same time.
+** Just don't use both at the same time. **
 By default, SSH and the basic Satellite server ports are opened using the firewall 
 services selections, and the one "Capsule" firewall ports 7911, 8000, and 8443 
 that aren't part of the RH-Satelite-6 service are opened individually.

--- a/vars/answer-file.yml
+++ b/vars/answer-file.yml
@@ -1,0 +1,26 @@
+---
+answer_file_settings:
+  - { regex: 'parent_fqdn', setting: "satellite.example.com" }
+  - { regex: 'pulp_admin_password', setting: "password" }
+  - { regex: 'satellite_initial_organization', setting: "example_corp" }
+  - { regex: 'satellite_initial_location', setting: "home" }
+  - { regex: 'satellite_admin_user', setting: "admin" }
+  - { regex: 'satellite_admin_passwd', setting: "password" }
+  - { regex: 'satellite_db_username', setting: "foreman" }
+  - { regex: 'satellite_db_password', setting: "password" }
+  - { regex: 'system_name', setting: "satellite.example.com" }
+  - { regex: 'system_name_http', setting: "http://satellite.example.com:8000" }
+  - { regex: 'system_name_https', setting: "https://satellite.example.com" }
+  - { regex: 'system_name_puppet', setting: "https://satellite.example.com:8140" }
+  - { regex: 'dns_tsig_principal_entry', setting: "foremanproxy/satellite.internal@example.com.internal" }
+  - { regex: 'ca_gen_certificate', setting: "true" }
+  - { regex: 'ca_country', setting: "US" }
+  - { regex: 'ca_state', setting: "North Carolina" }
+  - { regex: 'ca_city', setting: "Raleigh" }
+  - { regex: 'ca_org', setting: "Katello" }
+  - { regex: 'ca_org_unit', setting: "SomeOrgUnit" }
+  - { regex: 'ca_crt_expiration', setting: "36500" }
+  - { regex: 'ca_default_name', setting: "katello-default-ca" }
+  - { regex: 'ca_default_sever_name', setting: "katello-server-ca" }
+
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,34 +24,6 @@ rhn_registration: True
 rhn_user: "CHANGEME"
 rhn_password: "CHANGEME"
 
-##########################################
-### SATELLITE CONFIGURATION VARIABLES  ###
-##########################################
-
-#Common variables
-satellite_initial_organization: "example_corp"
-satellite_initial_location: "home"
-satellite_admin_user: "admin"
-satellite_admin_passwd: "password"
-satelite_db_username: "foreman"
-satellite_db_password: "password"
-system_name: "satellite.example.com"
-system_name_http: "http://satellite.example.com:8000"
-system_name_https: "https://satellite.example.com"
-system_name_puppet: "https://satellite.example.com:8140"
-dns_tsig_principal_entry: "foremanproxy/satellite.internal@example.com.internal"
-
-#CA Certificates
-ca_country: "US"
-ca_state: "North Carolina"
-ca_city: "Raleigh"
-ca_org: "Katello"
-ca_org_unit: "example"
-ca_expiration: "36500"
-ca_server_cert: ""
-ca_server_cert_req: ""
-ca_server_ca_cert: ""
-
 ############################
 ##### FIREWALL VARIABLES #####
 ############################

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,71 +24,80 @@ rhn_registration: True
 rhn_user: "CHANGEME"
 rhn_password: "CHANGEME"
 
- ##########################################
-##### SATELLITE CONFIGURATION VARIABLES #####
- ##########################################
+##########################################
+### SATELLITE CONFIGURATION VARIABLES  ###
+##########################################
 
-gateway: "192.168.2.142"
-dhcp_mgmt_interface: "eth1"
-dhcp_name_server: ""
-dhcp_subnet: "10.10.1.0"
-dhcp_start: "10.10.1.150"
-dhcp_end: "10.10.1.200"
-dhcp_mask: "255.255.255.0"
-dhcp_net_name: "10.10.1.X"
-ip_address_sat: "192.168.2.142"
-forwarder_dns: "8.8.8.8"
-dns_interface: "eth1"
-dns_zone: "quebolon.local"
-dns_reverse_zone: "10.10.in-addr.arpa"
-organization: "quebolon"
-location: "home"
-admin_user: "admin"
-admin_passwd: "password"
-puppet_env: "production"
-hostname_full: "satellite.quebolon.local"
-hostname_short: "satellite"
-subnet_dhcp_name_server: ""
-subnet_dhcp_subnet: "10.10.2.0"
-subnet_dhcp_start: "10.10.2.150"
-subnet_dhcp_end: "10.10.2.200"
-subnet_dhcp_mask: "255.255.255.0"
-subnet_dhcp_net_name: "10.10.2.X"
+#Common variables
+satellite_initial_organization: "example_corp"
+satellite_initial_location: "home"
+satellite_admin_user: "admin"
+satellite_admin_passwd: "password"
+satelite_db_username: "foreman"
+satellite_db_password: "password"
+system_name: "satellite.example.com"
+system_name_http: "http://satellite.example.com:8000"
+system_name_https: "https://satellite.example.com"
+system_name_puppet: "https://satellite.example.com:8140"
+dns_tsig_principal_entry: "foremanproxy/satellite.internal@example.com.internal"
 
- ############################
+#CA Certificates
+ca_country: "US"
+ca_state: "North Carolina"
+ca_city: "Raleigh"
+ca_org: "Katello"
+ca_org_unit: "example"
+ca_expiration: "36500"
+ca_server_cert: ""
+ca_server_cert_req: ""
+ca_server_ca_cert: ""
+
+############################
 ##### FIREWALL VARIABLES #####
- ############################
+############################
 
 # List of service to add into the firewall via Firewalld
+# See README.md for an explanation.
 firewall_services:
+  - ssh
   - RH-Satellite-6
+# - dns
+# - dhcp
+# - dhcpv6
+# - tftp
+# - libvirt-tls
+# - ldap
+# - ldaps
+# - docker-registry
+# - vnc-server
 
 # List of ports to add into the firewall via Firewalld
+# See README.md for an explanation.
 firewall_ports:
-  - 22/tcp
-  - 53/udp
-  - 53/tcp
-  - 67/udp
-  - 68/udp
-  - 69/udp
-  - 80/tcp
-  - 389/tcp
-  - 443/tcp
-  - 639/tcp
-  - 5000/tcp
-  - 5646/tcp
-  - 5647/tcp
-  - 5671/tcp
-  - 5674/tcp
+# - 22/tcp
+# - 53/udp
+# - 53/tcp
+# - 67/udp
+# - 68/udp
+# - 69/udp
+# - 80/tcp
+# - 389/tcp
+# - 443/tcp
+# - 639/tcp
+# - 5000/tcp
+# - 5646/tcp
+# - 5647/tcp
+# - 5671/tcp
+# - 5674/tcp
   - 7911/tcp
   - 8000/tcp
-  - 8140/tcp
+# - 8140/tcp
   - 8443/tcp
-  - 9090/tcp
-  - 16514/tcp
+# - 9090/tcp
+# - 16514/tcp
 
  ##########################################
-##### REPOSITORY AND PACKAGE VARIABLES #####
+ ##### REPOSITORY AND PACKAGE VARIABLES ###
  ##########################################
 
 # Packages to be installed via YUM. Add another line for any additional


### PR DESCRIPTION
I added tasks to the install_satellite.yml file that will create a customized satellite-answers.yaml file in /etc/foreman-inataller/scenarios.d/satellite-answers.yaml

I also added vars/answer-file.yml and templates/satellite-answers.yaml files.
I also updated vars/main.yml to resolve port vs firewalld:service conflicts.  There is a README.md explaining this, so the user may choose to open firewalld ports, or rely on the existing firewalld services.

TODO: Cover disconnected installations, and iptables using servers.